### PR TITLE
Let the enemy heal only when its health is below a set value

### DIFF
--- a/sigma_rizzler.c
+++ b/sigma_rizzler.c
@@ -394,16 +394,26 @@ void enemyTurn(int round)
     srand(time(NULL));
     int random = (rand() % 9);
     int amount = 0;
-    if (random > 5)
+    float enemyHealthHalf = enemy->health * 0.6;
+    if ((float)enemy->health < enemyHealthHalf)
+    {
+        if (random > 5)
+        {
+            amount = attack(round);
+            printf("The bot attacked you with %d damage\n", amount);
+        }
+        else
+        {
+            amount = heal(round);
+            printf("The bot healed himself with %d HP\n", amount);
+        }  
+    }
+    else
     {
         amount = attack(round);
         printf("The bot attacked you with %d damage\n", amount);
     }
-    else
-    {
-        amount = heal(round);
-        printf("The bot healed himself with %d HP\n", amount);
-    }
+    
 }
 
 void playerTurn(Enemy *enemy, int round)


### PR DESCRIPTION
With the current random behavior, the enemy sometimes chooses to heal itself, despite its health still pretty high. Which makes the behavior a bit weird.

This commit adds a condition on top of the existing random picker that will only let the enemy heal when its health is lower than a set value (eg. less than 60%). We can change this value depending on the difficulty. For example, make the enemy heal at higher health on harder difficulty.

Any suggestions? @GilbertOwen @Belugerz 